### PR TITLE
require one of individual or organization name in metadata-point-of-contact

### DIFF
--- a/cioos-siooc_schema.json
+++ b/cioos-siooc_schema.json
@@ -531,12 +531,13 @@
            "field_name": "individual-name",
            "label": "Name",
            "form_placeholder": "Joe Bloggs",
-           "required": true,
+           "require_one": true,
            "hint": "name of orginization or individual"
          },
          {
            "field_name": "organisation-name",
            "label": "Affiliation",
+           "require_one": true,
            "preset": "dataset_organization"
          },
          {


### PR DESCRIPTION
fix cioos-siooc/ckan#52
no longer required to have an individual name. point of contact can now be an organization with a generic email.
