### PR TITLE
Added icon that populates in interface. "eov_other.svg" previously none.svg

### DIFF
--- a/cioos-siooc_schema.json
+++ b/cioos-siooc_schema.json
@@ -185,7 +185,7 @@
           "category": "Other",
           "value": "other",
           "label": "Other",
-          "icon": "none.svg"
+          "icon": "eov_other.svg"
         }
       ]
     },


### PR DESCRIPTION
The none.svg icon doesn't exist in the theme that I know of, replaced with the eov_other.svg to get icon unbroken.