### PR TITLE
remove tag_length_validator on keyword field so that longer keywords, such as found in NERC (http://vocab.nerc.ac.uk/collection/P01/current/) can be used

### DIFF
--- a/cioos-siooc_schema.json
+++ b/cioos-siooc_schema.json
@@ -45,7 +45,7 @@
       "preset": "fluent_tags",
       "display_snippet": null,
       "required": true,
-      "tag_validators": "tag_length_validator cioos_tag_name_validator",
+      "tag_validators": "cioos_tag_name_validator",
       "label": {
         "fr": "Mots-clés",
         "en": "Keywords"


### PR DESCRIPTION
fixes https://github.com/cioos-siooc/ckan/issues/126